### PR TITLE
feat: route to machine

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 LISTEN=localhost:8080
 DATA_FILE_PATH=./data.bin
+FLY_MACHINE_ID=local

--- a/server.go
+++ b/server.go
@@ -131,6 +131,16 @@ func getReqRoomUser(r *http.Request) (*Room, *User) {
 }
 
 func getRoomHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println(machineId, "received request for", r.URL)
+
+	urlMachineId := r.PathValue("machine")
+	if urlMachineId != machineId {
+		w.Header().Add("fly-replay", fmt.Sprintf("instance=%s", urlMachineId))
+		log.Println(machineId, "added header to redirect to", urlMachineId)
+		notFoundHandler(w, r)
+		return
+	}
+
 	room, user := getReqRoomUser(r)
 
 	if room == nil {

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,12 +46,14 @@
       </footer>
 
       <script>
-        const machineId = document.cookie
-          .split("; ")
-          .find((row) => row.startsWith("machineId="))
-          ?.split("=")[1];
         document.body.addEventListener("htmx:configRequest", function (e) {
-          e.detail.headers["fly-force-instance-id"] = machineId;
+          const machineId = document.cookie
+            .split("; ")
+            .find((row) => row.startsWith("machineId="))
+            ?.split("=")[1];
+          if (machineId) {
+            e.detail.headers["fly-force-instance-id"] = machineId;
+          }
         });
       </script>
     </body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,6 +44,16 @@
           >
         </small>
       </footer>
+
+      <script>
+        const machineId = document.cookie
+          .split("; ")
+          .find((row) => row.startsWith("machineId="))
+          ?.split("=")[1];
+        document.body.addEventListener("htmx:configRequest", function (e) {
+          e.detail.headers["fly-force-instance-id"] = machineId;
+        });
+      </script>
     </body>
   </html>
 {{ end }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
   <section>
     {{ if and .Room }}
       <a
-        href="/room/{{ .Room.Id }}"
+        href="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
         hx-boost="true"
         role="button"
         style="display: block;"

--- a/templates/room.html
+++ b/templates/room.html
@@ -16,7 +16,7 @@
 
   {{ if not .User }}
     <section>
-      <form action="/room/{{ .Room.Id }}" method="post">
+      <form action="/room/{{ .Room.MachineId }}/{{ .Room.Id }}" method="post">
         <label>
           Your name
           <fieldset role="group">
@@ -31,9 +31,9 @@
       <details>
         <summary>Manage room</summary>
         <form
-          action="/room/{{ .Room.Id }}"
+          action="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
           method="post"
-          hx-post="/room/{{ .Room.Id }}"
+          hx-post="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
           hx-swap="none"
           hx-sync="#updater:replace"
         >
@@ -103,9 +103,9 @@
     {{ block "options" . }}
       <section id="options" hx-swap-oob="true">
         <form
-          action="/room/{{ .Room.Id }}"
+          action="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
           method="post"
-          hx-post="/room/{{ .Room.Id }}"
+          hx-post="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
           hx-swap="none"
           hx-sync="#updater:replace"
           class="grid"
@@ -124,9 +124,9 @@
 
         {{ if eq .Room.HostId .User.Id }}
           <form
-            action="/room/{{ .Room.Id }}"
+            action="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
             method="post"
-            hx-post="/room/{{ .Room.Id }}"
+            hx-post="/room/{{ .Room.MachineId }}/{{ .Room.Id }}"
             hx-swap="none"
             hx-sync="#updater:replace"
           >
@@ -181,7 +181,7 @@
 
     <div
       id="updater"
-      hx-get="/room/{{ .Room.Id }}/update"
+      hx-get="/room/{{ .Room.MachineId }}/{{ .Room.Id }}/update"
       hx-trigger="every 1s"
       hx-swap="none"
       hx-sync="this:abort"


### PR DESCRIPTION
- rooms now have associated machines in the url, that allow fly machines to redirect requests to the right machine
  - rooms are not shared between machines (data is local), so trying to enter a room on the wrong machine is a 404
- this allows "horizontal scaling" and "deploying to the edge" :D
- this is optional and doesn't do anything if you're not using fly.io; FLY_MACHINE_ID can be any value like your hostname 
 
Closes #1
